### PR TITLE
Fixes to get working on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-atty = "0.2"
+atty = "0.2.14"
 colored = "3.0.0"
 dirs = "5.0.1"
 grep = "0.3.2"

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ iwr -useb https://raw.githubusercontent.com/buger/probe/main/install.ps1 | iex -
 2. Clone this repository:
    ~~~bash
    git clone https://github.com/buger/probe.git
-   cd code-search
+   cd probe
    ~~~
 3. Build the project:
    ~~~bash


### PR DESCRIPTION
I checked out the repo and built on Windows.  Had to make a couple of fixes to get it to build.

- One out of date instruction in the Readme.
- Also had to specify atty v0.2.14.  v0.2 didn't work. 

I don't know why v0.2 didn't pull the latest version of atty.  This was a completely fresh install of rust on this PC, following the instructions in the README.
