### PR TITLE
Fix crates.io publishing to use CARGO_REGISTRY_TOKEN environment variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,9 @@ jobs:
         run: cargo package --list
 
       - name: Publish to crates.io
-        run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
   publish-mcp-agent:
     name: Publish MCP Agent to npm


### PR DESCRIPTION
## Summary
- Changed crates.io publishing job to use `CARGO_REGISTRY_TOKEN` environment variable instead of passing token as command line argument
- This follows cargo's recommended authentication approach and is more secure

## Test plan
- [ ] Verify the workflow syntax is valid
- [ ] Test that crates.io publishing works correctly on next release

🤖 Generated with [Claude Code](https://claude.ai/code)