### PR TITLE
Fix probe workflow artifact conflicts and add jsonl to gitignore

### DIFF
--- a/.github/workflows/probe.yml
+++ b/.github/workflows/probe.yml
@@ -1094,7 +1094,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: probe-debug-files
+          name: probe-debug-files-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}
           path: |
             error.log
             formatted_prompt.txt
@@ -1114,7 +1114,7 @@ jobs:
         if: always() && inputs.enable_tracing && inputs.tracing_url == ''
         uses: actions/upload-artifact@v4
         with:
-          name: probe-traces
+          name: probe-traces-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}
           path: |
             probe-traces.jsonl
           if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ package-lock.json
 # Logs
 logs
 *.log
+*.jsonl
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*


### PR DESCRIPTION
## Summary
- Fix artifact naming conflicts in probe workflow by adding unique identifiers (run_id, run_attempt, job name)
- Add *.jsonl to .gitignore to ignore trace files generated by probe

## Changes
1. **Workflow artifact naming**: Updated artifact names to include `${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}` to prevent conflicts when multiple jobs run in parallel
2. **Gitignore update**: Added `*.jsonl` pattern to ignore OpenTelemetry trace files generated by probe

## Test plan
- [x] Verified workflow file changes are syntactically correct
- [x] Confirmed gitignore properly ignores jsonl files
- [x] Both changes are minimal and focused

🤖 Generated with [Claude Code](https://claude.ai/code)