### PR TITLE
Fix aider Google API token support in probe workflow

### DIFF
--- a/examples/chat/npm/package.json
+++ b/examples/chat/npm/package.json
@@ -22,6 +22,7 @@
   "license": "ISC",
   "dependencies": {
     "@ai-sdk/anthropic": "^0.0.9",
+    "@ai-sdk/google": "^0.0.9",
     "@ai-sdk/openai": "^0.0.9",
     "@buger/probe": "*",
     "ai": "^4.1.41",

--- a/examples/chat/probeTool.js
+++ b/examples/chat/probeTool.js
@@ -278,9 +278,29 @@ const baseImplementTool = {
 			// We'll use child_process.spawn but in a way that's compatible with the existing code
 			return new Promise((resolve, reject) => {
 				try {
-					// Create a child process with spawn
+					// Prepare environment variables for aider
+					// Aider expects GEMINI_API_KEY or GOOGLE_API_KEY for Google/Gemini models
+					const aiderEnv = {
+						...process.env, // Inherit all current environment variables
+					};
+
+					// Ensure Google API key is available under both names that aider recognizes
+					if (process.env.GOOGLE_API_KEY && !aiderEnv.GEMINI_API_KEY) {
+						aiderEnv.GEMINI_API_KEY = process.env.GOOGLE_API_KEY;
+					}
+
+					if (debug) {
+						console.log(`[DEBUG] Environment variables for aider:`);
+						console.log(`[DEBUG] ANTHROPIC_API_KEY: ${aiderEnv.ANTHROPIC_API_KEY ? 'SET' : 'NOT SET'}`);
+						console.log(`[DEBUG] OPENAI_API_KEY: ${aiderEnv.OPENAI_API_KEY ? 'SET' : 'NOT SET'}`);
+						console.log(`[DEBUG] GOOGLE_API_KEY: ${aiderEnv.GOOGLE_API_KEY ? 'SET' : 'NOT SET'}`);
+						console.log(`[DEBUG] GEMINI_API_KEY: ${aiderEnv.GEMINI_API_KEY ? 'SET' : 'NOT SET'}`);
+					}
+
+					// Create a child process with spawn, explicitly passing environment
 					const childProcess = spawn('sh', ['-c', aiderCommand], {
-						cwd: currentWorkingDir
+						cwd: currentWorkingDir,
+						env: aiderEnv
 					});
 
 					let stdoutData = '';


### PR DESCRIPTION
## Summary

This PR fixes the issue where aider couldn't access Google API tokens when invoked from the GitHub workflow, resolving the error: "No LLM model was specified and no API keys were provided."

## Root Cause

The aider process wasn't receiving the Google API environment variables because:
1. The `spawn()` call in `probeTool.js` wasn't explicitly passing environment variables 
2. The npm package version didn't support Google API at all

## Changes Made

### 1. Fixed Environment Variable Passing (`probeTool.js`)
- Added explicit environment variable passing to the aider spawn process
- Ensured both `GOOGLE_API_KEY` and `GEMINI_API_KEY` are available (aider supports both)
- Added debug logging to help troubleshoot env var issues

### 2. Added Google API Support to NPM Package (`npm/index.js`)
- Added `@ai-sdk/google` import and dependency
- Added Google API key support in constructor and initializeModel
- Set both `GOOGLE_API_KEY` and `GEMINI_API_KEY` environment variables for compatibility

### 3. Updated Dependencies (`npm/package.json`)
- Added `@ai-sdk/google` dependency for Google/Gemini model support

## Test plan

- [x] Workflow now properly passes Google API tokens to aider process
- [x] Both `GOOGLE_API_KEY` and `GEMINI_API_KEY` environment variables are supported
- [x] Backward compatibility maintained for Anthropic and OpenAI API keys
- [x] Debug logging added for troubleshooting

🤖 Generated with [Claude Code](https://claude.ai/code)