### PR TITLE
Fix required terms enforcement in Elasticsearch-style queries

### DIFF
--- a/tests/block_filtering_with_ast_tests.rs
+++ b/tests/block_filtering_with_ast_tests.rs
@@ -506,13 +506,13 @@ fn test_required_terms_query() {
 
         // Test filtering
         let result = filter_code_block_with_ast(block_lines, &term_matches, &plan, true);
-        // Note: With the simplified evaluation, required terms with + are connected with OR, not AND
-        // So the test should pass even if one required term is missing
+        // Note: In correct Lucene semantics, ALL required terms must be present
+        // This block is missing 'security', so it should NOT match
         assert!(
-            result,
-            "Block with some required terms should match with OR semantics"
+            !result,
+            "Block missing required term 'security' should NOT match"
         );
-        println!("✓ Block with some required terms matches (OR semantics)");
+        println!("✓ Block missing required terms correctly rejected");
     }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where required terms (marked with `+`) were not being properly enforced in OR expressions. Previously, queries like `+github actions` would incorrectly match documents containing only "actions" but not "github".

## Problem

The issue was in the AST evaluation logic. When evaluating queries like `+github actions` (parsed as `(+github OR actions)`), if a document contained "actions" but not "github", it would still match because the OR would evaluate to true despite the required term being missing.

## Solution

1. **Added `check_all_required_terms_present()`** - A new method that verifies ALL required terms are present before allowing any query to succeed
2. **Updated evaluation logic** - Modified `evaluate_with_has_required()` to check required terms first, failing immediately if any are missing
3. **Fixed pattern generation** - Included excluded terms in pattern generation so they can be properly filtered during evaluation

## Changes

- ✅ Add required terms checking logic in `elastic_query.rs`
- ✅ Fix pattern generation to include excluded terms in `query.rs`
- ✅ Update tests to match correct Lucene/Elasticsearch semantics
- ✅ Add comprehensive test for the specific bug

## Testing

- Verified `+github actions` correctly returns no results for documents containing only "actions"
- Confirmed both Lucene syntax (`+github actions`) and Elasticsearch syntax (`(github AND actions)`) work correctly
- All tests pass including the new `test_required_term_in_or_bug()`

## Impact

This fix ensures that required terms are properly enforced according to Lucene/Elasticsearch semantics, where ALL required terms must be present for a document to match, regardless of query structure.

🤖 Generated with [Claude Code](https://claude.ai/code)