### PR TITLE
Fix Docker build: Restore benches directory for Cargo manifest validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,9 @@ WORKDIR /usr/src/probe
 COPY Cargo.toml Cargo.lock* ./
 # Copy source code
 COPY src ./src
-# Note: benches/ directory not needed for production builds
-# Benchmarks are only used during development with `cargo bench`
+# Copy benches - required because Cargo.toml declares benchmark targets
+# Even for release builds, Cargo validates that benchmark files exist
+COPY benches ./benches
 
 # Build the project in release mode (this will generate Cargo.lock if missing)
 RUN cargo build --release


### PR DESCRIPTION
## Summary
Fix Docker build by restoring the benches directory copy, which is required for Cargo manifest validation.

## Problem
After removing the benches directory copy in PR #98, the Docker build is now failing with:
```
error: failed to parse manifest at `/usr/src/probe/Cargo.toml`
Caused by:
  can't find `parsing_benchmarks` bench at `benches/parsing_benchmarks.rs`
```

## Root Cause
The issue is that `Cargo.toml` declares benchmark targets:
```toml
[[bench]]
name = "parsing_benchmarks"
harness = false
# ... more benchmarks
```

Even for release builds, Cargo validates that all declared targets exist. Without the benches directory, `cargo build --release` fails during manifest parsing.

## Solution
Restore the `COPY benches ./benches` line in the Dockerfile because:
- Cargo.toml declares benchmark targets that must exist for any build
- Cargo validates manifest integrity even for release builds
- The benchmark files are needed for Cargo's dependency resolution
- This is a requirement of Cargo's build system, not just development

## Test plan
- [x] Docker build should now succeed with benches directory present
- [x] Cargo manifest validation passes
- [x] Production functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)