### PR TITLE
Fix JSON/XML extract output pollution

### DIFF
--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -74,36 +74,36 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
     let debug_mode = std::env::var("DEBUG").unwrap_or_default() == "1";
 
     if debug_mode {
-        println!("\n[DEBUG] ===== Extract Command Started =====");
-        println!("[DEBUG] Files to process: {files:?}", files = options.files);
-        println!(
+        eprintln!("\n[DEBUG] ===== Extract Command Started =====");
+        eprintln!("[DEBUG] Files to process: {files:?}", files = options.files);
+        eprintln!(
             "[DEBUG] Custom ignores: {custom_ignores:?}",
             custom_ignores = options.custom_ignores
         );
-        println!(
+        eprintln!(
             "[DEBUG] Context lines: {context_lines}",
             context_lines = options.context_lines
         );
-        println!("[DEBUG] Output format: {format}", format = options.format);
-        println!(
+        eprintln!("[DEBUG] Output format: {format}", format = options.format);
+        eprintln!(
             "[DEBUG] Read from clipboard: {from_clipboard}",
             from_clipboard = options.from_clipboard
         );
-        println!(
+        eprintln!(
             "[DEBUG] Write to clipboard: {to_clipboard}",
             to_clipboard = options.to_clipboard
         );
-        println!("[DEBUG] Dry run: {dry_run}", dry_run = options.dry_run);
-        println!("[DEBUG] Parse as git diff: {diff}", diff = options.diff);
-        println!(
+        eprintln!("[DEBUG] Dry run: {dry_run}", dry_run = options.dry_run);
+        eprintln!("[DEBUG] Parse as git diff: {diff}", diff = options.diff);
+        eprintln!(
             "[DEBUG] Allow tests: {allow_tests}",
             allow_tests = options.allow_tests
         );
-        println!(
+        eprintln!(
             "[DEBUG] Prompt template: {prompt:?}",
             prompt = options.prompt
         );
-        println!(
+        eprintln!(
             "[DEBUG] Instructions: {instructions:?}",
             instructions = options.instructions
         );
@@ -119,7 +119,9 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
 
     if options.from_clipboard {
         // Read from clipboard
-        println!("{}", "Reading from clipboard...".bold().blue());
+        if options.format != "json" && options.format != "xml" {
+            println!("{}", "Reading from clipboard...".bold().blue());
+        }
         let mut clipboard = Clipboard::new()?;
         let buffer = clipboard.get_text()?;
 
@@ -127,7 +129,7 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
         if options.keep_input {
             original_input = Some(buffer.clone());
             if debug_mode {
-                println!(
+                eprintln!(
                     "[DEBUG] Stored original clipboard input: {} bytes",
                     original_input.as_ref().map_or(0, |s| s.len())
                 );
@@ -135,7 +137,7 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
         }
 
         if debug_mode {
-            println!(
+            eprintln!(
                 "[DEBUG] Reading from clipboard, content length: {} bytes",
                 buffer.len()
             );
@@ -147,7 +149,7 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
         if is_diff_format {
             // Parse as git diff format
             if debug_mode {
-                println!("[DEBUG] Parsing clipboard content as git diff format");
+                eprintln!("[DEBUG] Parsing clipboard content as git diff format");
             }
             file_paths = extract_file_paths_from_git_diff(&buffer, options.allow_tests);
         } else {
@@ -156,12 +158,12 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
         }
 
         if debug_mode {
-            println!(
+            eprintln!(
                 "[DEBUG] Extracted {} file paths from clipboard",
                 file_paths.len()
             );
             for (path, start, end, symbol, lines) in &file_paths {
-                println!(
+                eprintln!(
                     "[DEBUG]   - {:?} (lines: {:?}-{:?}, symbol: {:?}, specific lines: {:?})",
                     path,
                     start,
@@ -173,17 +175,21 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
         }
 
         if file_paths.is_empty() {
-            println!("{}", "No file paths found in clipboard.".yellow().bold());
+            if options.format != "json" && options.format != "xml" {
+                println!("{}", "No file paths found in clipboard.".yellow().bold());
+            }
             return Ok(());
         }
     } else if let Some(input_file_path) = &options.input_file {
         // Read from input file
-        println!(
-            "{}",
-            format!("Reading from file: {input_file_path}...")
-                .bold()
-                .blue()
-        );
+        if options.format != "json" && options.format != "xml" {
+            println!(
+                "{}",
+                format!("Reading from file: {input_file_path}...")
+                    .bold()
+                    .blue()
+            );
+        }
 
         // Check if the file exists
         let input_path = std::path::Path::new(input_file_path);
@@ -201,7 +207,7 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
         if options.keep_input {
             original_input = Some(buffer.clone());
             if debug_mode {
-                println!(
+                eprintln!(
                     "[DEBUG] Stored original file input: {} bytes",
                     original_input.as_ref().map_or(0, |s| s.len())
                 );
@@ -209,7 +215,7 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
         }
 
         if debug_mode {
-            println!(
+            eprintln!(
                 "[DEBUG] Reading from file, content length: {} bytes",
                 buffer.len()
             );
@@ -221,7 +227,7 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
         if is_diff_format {
             // Parse as git diff format
             if debug_mode {
-                println!("[DEBUG] Parsing file content as git diff format");
+                eprintln!("[DEBUG] Parsing file content as git diff format");
             }
             file_paths = extract_file_paths_from_git_diff(&buffer, options.allow_tests);
         } else {
@@ -230,12 +236,12 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
         }
 
         if debug_mode {
-            println!(
+            eprintln!(
                 "[DEBUG] Extracted {} file paths from input file",
                 file_paths.len()
             );
             for (path, start, end, symbol, lines) in &file_paths {
-                println!(
+                eprintln!(
                     "[DEBUG]   - {:?} (lines: {:?}-{:?}, symbol: {:?}, specific lines: {:?})",
                     path,
                     start,
@@ -247,12 +253,14 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
         }
 
         if file_paths.is_empty() {
-            println!(
-                "{}",
-                format!("No file paths found in input file: {input_file_path}")
-                    .yellow()
-                    .bold()
-            );
+            if options.format != "json" && options.format != "xml" {
+                println!(
+                    "{}",
+                    format!("No file paths found in input file: {input_file_path}")
+                        .yellow()
+                        .bold()
+                );
+            }
             return Ok(());
         }
     } else if options.files.is_empty() {
@@ -261,7 +269,9 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
 
         if is_stdin_available {
             // Read from stdin
-            println!("{}", "Reading from stdin...".bold().blue());
+            if options.format != "json" && options.format != "xml" {
+                println!("{}", "Reading from stdin...".bold().blue());
+            }
             let mut buffer = String::new();
             std::io::stdin().read_to_string(&mut buffer)?;
 
@@ -269,7 +279,7 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
             if options.keep_input {
                 original_input = Some(buffer.clone());
                 if debug_mode {
-                    println!(
+                    eprintln!(
                         "[DEBUG] Stored original stdin input: {} bytes",
                         original_input.as_ref().map_or(0, |s| s.len())
                     );
@@ -277,7 +287,7 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
             }
 
             if debug_mode {
-                println!(
+                eprintln!(
                     "[DEBUG] Reading from stdin, content length: {} bytes",
                     buffer.len()
                 );
@@ -289,7 +299,7 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
             if is_diff_format {
                 // Parse as git diff format
                 if debug_mode {
-                    println!("[DEBUG] Parsing stdin content as git diff format");
+                    eprintln!("[DEBUG] Parsing stdin content as git diff format");
                 }
                 file_paths = extract_file_paths_from_git_diff(&buffer, options.allow_tests);
             } else {
@@ -298,23 +308,25 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
             }
         } else {
             // No arguments and no stdin, show help
-            println!(
-                "{}",
-                "No files specified and no stdin input detected."
-                    .yellow()
-                    .bold()
-            );
-            println!("{}", "Use --help for usage information.".blue());
+            if options.format != "json" && options.format != "xml" {
+                println!(
+                    "{}",
+                    "No files specified and no stdin input detected."
+                        .yellow()
+                        .bold()
+                );
+                println!("{}", "Use --help for usage information.".blue());
+            }
             return Ok(());
         }
 
         if debug_mode {
-            println!(
+            eprintln!(
                 "[DEBUG] Extracted {} file paths from stdin",
                 file_paths.len()
             );
             for (path, start, end, symbol, lines) in &file_paths {
-                println!(
+                eprintln!(
                     "[DEBUG]   - {:?} (lines: {:?}-{:?}, symbol: {:?}, specific lines: {:?})",
                     path,
                     start,
@@ -326,20 +338,22 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
         }
 
         if file_paths.is_empty() {
-            println!("{}", "No file paths found in stdin.".yellow().bold());
+            if options.format != "json" && options.format != "xml" {
+                println!("{}", "No file paths found in stdin.".yellow().bold());
+            }
             return Ok(());
         }
     } else {
         // Parse command-line arguments
         if debug_mode {
-            println!("[DEBUG] Parsing command-line arguments");
+            eprintln!("[DEBUG] Parsing command-line arguments");
         }
 
         // Store the original input if keep_input is true
         if options.keep_input {
             original_input = Some(options.files.join(" "));
             if debug_mode {
-                println!(
+                eprintln!(
                     "[DEBUG] Stored original command-line input: {}",
                     original_input.as_ref().unwrap_or(&String::new())
                 );
@@ -348,19 +362,19 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
 
         for file in &options.files {
             if debug_mode {
-                println!("[DEBUG] Parsing file argument: {file}");
+                eprintln!("[DEBUG] Parsing file argument: {file}");
             }
 
             let paths = file_paths::parse_file_with_line(file, options.allow_tests);
 
             if debug_mode {
-                println!(
+                eprintln!(
                     "[DEBUG] Parsed {} paths from argument '{}'",
                     paths.len(),
                     file
                 );
                 for (path, start, end, symbol, lines) in &paths {
-                    println!(
+                    eprintln!(
                         "[DEBUG]   - {:?} (lines: {:?}-{:?}, symbol: {:?}, specific lines: {:?})",
                         path,
                         start,
@@ -427,7 +441,7 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
     // Process prompt template and instructions if provided
     let system_prompt = if let Some(prompt_template) = &options.prompt {
         if debug_mode {
-            println!("[DEBUG] Processing prompt template: {prompt_template:?}");
+            eprintln!("[DEBUG] Processing prompt template: {prompt_template:?}");
         }
         match prompt_template.get_content() {
             Ok(content) => {
@@ -445,7 +459,7 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
                     text = format!("Error loading prompt template: {e}").red()
                 );
                 if debug_mode {
-                    println!("[DEBUG] Error loading prompt template: {e}");
+                    eprintln!("[DEBUG] Error loading prompt template: {e}");
                 }
                 None
             }
@@ -506,24 +520,24 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
     // Process files in parallel
     file_params.par_iter().for_each(|params| {
         if params.debug_mode {
-            println!("\n[DEBUG] Processing file: {:?}", params.path);
-            println!("[DEBUG] Start line: {:?}", params.start_line);
-            println!("[DEBUG] End line: {:?}", params.end_line);
-            println!("[DEBUG] Symbol: {:?}", params.symbol);
-            println!(
+            eprintln!("\n[DEBUG] Processing file: {:?}", params.path);
+            eprintln!("[DEBUG] Start line: {:?}", params.start_line);
+            eprintln!("[DEBUG] End line: {:?}", params.end_line);
+            eprintln!("[DEBUG] Symbol: {:?}", params.symbol);
+            eprintln!(
                 "[DEBUG] Specific lines: {:?}",
                 params.specific_lines.as_ref().map(|l| l.len())
             );
 
             // Check if file exists
             if params.path.exists() {
-                println!("[DEBUG] File exists: Yes");
+                eprintln!("[DEBUG] File exists: Yes");
 
                 // Get file extension and language
                 if let Some(ext) = params.path.extension().and_then(|e| e.to_str()) {
                     let language = formatter::get_language_from_extension(ext);
-                    println!("[DEBUG] File extension: {ext}");
-                    println!(
+                    eprintln!("[DEBUG] File extension: {ext}");
+                    eprintln!(
                         "[DEBUG] Detected language: {}",
                         if language.is_empty() {
                             "unknown"
@@ -532,17 +546,17 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
                         }
                     );
                 } else {
-                    println!("[DEBUG] File has no extension");
+                    eprintln!("[DEBUG] File has no extension");
                 }
             } else {
-                println!("[DEBUG] File exists: No");
+                eprintln!("[DEBUG] File exists: No");
             }
         }
 
         // The allow_tests check is now handled in the file path extraction functions
         // We only need to check if this is a test file for debugging purposes
         if params.debug_mode && crate::language::is_test_file(&params.path) && !params.allow_tests {
-            println!("[DEBUG] Test file detected: {:?}", params.path);
+            eprintln!("[DEBUG] Test file detected: {:?}", params.path);
         }
 
         match processor::process_file_for_extraction(
@@ -556,11 +570,11 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
         ) {
             Ok(result) => {
                 if params.debug_mode {
-                    println!("[DEBUG] Successfully extracted code from {:?}", params.path);
-                    println!("[DEBUG] Extracted lines: {:?}", result.lines);
-                    println!("[DEBUG] Node type: {}", result.node_type);
-                    println!("[DEBUG] Code length: {} bytes", result.code.len());
-                    println!(
+                    eprintln!("[DEBUG] Successfully extracted code from {:?}", params.path);
+                    eprintln!("[DEBUG] Extracted lines: {:?}", result.lines);
+                    eprintln!("[DEBUG] Node type: {}", result.node_type);
+                    eprintln!("[DEBUG] Code length: {} bytes", result.code.len());
+                    eprintln!(
                         "[DEBUG] Estimated tokens: {}",
                         crate::search::search_tokens::count_tokens(&result.code)
                     );
@@ -577,7 +591,7 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
                     e = e
                 );
                 if params.debug_mode {
-                    println!("[DEBUG] Error: {error_msg}");
+                    eprintln!("[DEBUG] Error: {error_msg}");
                 }
                 // Only print error messages for non-JSON/XML formats
                 if params.format != "json" && params.format != "xml" {
@@ -602,7 +616,7 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
 
     // Deduplicate results based on file path and line range
     if debug_mode {
-        println!(
+        eprintln!(
             "[DEBUG] Before deduplication: {len} results",
             len = results.len()
         );
@@ -626,9 +640,9 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
     });
 
     if debug_mode {
-        println!("[DEBUG] Sorted results by file path and range size");
+        eprintln!("[DEBUG] Sorted results by file path and range size");
         for (i, result) in results.iter().enumerate() {
-            println!(
+            eprintln!(
                 "[DEBUG] Result {}: {} (lines {}-{}, size: {})",
                 i,
                 result.file,
@@ -660,7 +674,7 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
         if !seen_exact.insert(key) {
             to_retain[i] = false;
             if debug_mode {
-                println!("[DEBUG] Removing exact duplicate: {file_i} (lines {start_i}-{end_i})");
+                eprintln!("[DEBUG] Removing exact duplicate: {file_i} (lines {start_i}-{end_i})");
             }
             continue;
         }
@@ -685,7 +699,7 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
             if start_j >= start_i && end_j <= end_i {
                 to_retain[j] = false;
                 if debug_mode {
-                    println!("[DEBUG] Removing nested duplicate: {file_j} (lines {start_j}-{end_j}) contained within (lines {start_i}-{end_i})");
+                    eprintln!("[DEBUG] Removing nested duplicate: {file_j} (lines {start_j}-{end_j}) contained within (lines {start_i}-{end_i})");
                 }
             }
         }
@@ -704,18 +718,18 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
     results = new_results;
 
     if debug_mode {
-        println!(
+        eprintln!(
             "[DEBUG] After deduplication: {len} results",
             len = results.len()
         );
     }
 
     if debug_mode {
-        println!("\n[DEBUG] ===== Extraction Summary =====");
-        println!("[DEBUG] Total results: {}", results.len());
-        println!("[DEBUG] Total errors: {}", errors.len());
-        println!("[DEBUG] Output format: {}", options.format);
-        println!("[DEBUG] Dry run: {}", options.dry_run);
+        eprintln!("\n[DEBUG] ===== Extraction Summary =====");
+        eprintln!("[DEBUG] Total results: {}", results.len());
+        eprintln!("[DEBUG] Total errors: {}", errors.len());
+        eprintln!("[DEBUG] Output format: {}", options.format);
+        eprintln!("[DEBUG] Dry run: {}", options.dry_run);
     }
 
     // Format the results
@@ -780,7 +794,7 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
                 eprintln!("{}", format!("Error formatting results: {e}").red());
             }
             if debug_mode {
-                println!("[DEBUG] Error formatting results: {e}");
+                eprintln!("[DEBUG] Error formatting results: {e}");
             }
         }
     }
@@ -797,7 +811,7 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
     }
 
     if debug_mode {
-        println!("[DEBUG] ===== Extract Command Completed =====");
+        eprintln!("[DEBUG] ===== Extract Command Completed =====");
     }
 
     Ok(())

--- a/src/extract/processor.rs
+++ b/src/extract/processor.rs
@@ -34,20 +34,20 @@ pub fn process_file_for_extraction(
     let debug_mode = std::env::var("DEBUG").unwrap_or_default() == "1";
 
     if debug_mode {
-        println!("\n[DEBUG] ===== Processing File for Extraction =====");
-        println!("[DEBUG] File path: {path:?}");
-        println!("[DEBUG] Start line: {start_line:?}");
-        println!("[DEBUG] End line: {end_line:?}");
-        println!("[DEBUG] Symbol: {symbol:?}");
-        println!("[DEBUG] Allow tests: {allow_tests}");
-        println!("[DEBUG] Context lines: {context_lines}");
-        println!("[DEBUG] Specific lines: {specific_lines:?}");
+        eprintln!("\n[DEBUG] ===== Processing File for Extraction =====");
+        eprintln!("[DEBUG] File path: {path:?}");
+        eprintln!("[DEBUG] Start line: {start_line:?}");
+        eprintln!("[DEBUG] End line: {end_line:?}");
+        eprintln!("[DEBUG] Symbol: {symbol:?}");
+        eprintln!("[DEBUG] Allow tests: {allow_tests}");
+        eprintln!("[DEBUG] Context lines: {context_lines}");
+        eprintln!("[DEBUG] Specific lines: {specific_lines:?}");
     }
 
     // Check if the file exists
     if !path.exists() {
         if debug_mode {
-            println!("[DEBUG] Error: File does not exist");
+            eprintln!("[DEBUG] Error: File does not exist");
         }
         return Err(anyhow::anyhow!("File does not exist: {:?}", path));
     }
@@ -57,15 +57,15 @@ pub fn process_file_for_extraction(
     let lines: Vec<&str> = content.lines().collect();
 
     if debug_mode {
-        println!("[DEBUG] File read successfully");
-        println!("[DEBUG] File size: {} bytes", content.len());
-        println!("[DEBUG] Line count: {}", lines.len());
+        eprintln!("[DEBUG] File read successfully");
+        eprintln!("[DEBUG] File size: {} bytes", content.len());
+        eprintln!("[DEBUG] Line count: {}", lines.len());
     }
 
     // If we have a symbol, find it in the file
     if let Some(symbol_name) = symbol {
         if debug_mode {
-            println!("[DEBUG] Looking for symbol: {symbol_name}");
+            eprintln!("[DEBUG] Looking for symbol: {symbol_name}");
         }
         // Find the symbol in the file
         return find_symbol_in_file(path, symbol_name, &content, allow_tests, context_lines);
@@ -74,7 +74,7 @@ pub fn process_file_for_extraction(
     // If we have a line range (start_line, end_line), gather AST blocks overlapping that range.
     if let (Some(start), Some(end)) = (start_line, end_line) {
         if debug_mode {
-            println!("[DEBUG] Extracting line range: {start}-{end} (with AST merging)");
+            eprintln!("[DEBUG] Extracting line range: {start}-{end} (with AST merging)");
         }
 
         // Clamp line numbers to valid ranges instead of failing
@@ -95,7 +95,7 @@ pub fn process_file_for_extraction(
         }
 
         if debug_mode && (clamped_start != start || clamped_end != end) {
-            println!(
+            eprintln!(
                 "[DEBUG] Requested lines {start}-{end} out of range; clamping to {clamped_start}-{clamped_end}"
             );
         }
@@ -143,7 +143,7 @@ pub fn process_file_for_extraction(
                 let merged_end = max_end + 1;
 
                 if debug_mode {
-                    println!(
+                    eprintln!(
                         "[DEBUG] Found {} overlapping AST blocks, merging into lines {}-{}",
                         blocks.len(),
                         merged_start,
@@ -190,7 +190,7 @@ pub fn process_file_for_extraction(
             _ => {
                 // Fallback to literal extraction of lines [start..end]
                 if debug_mode {
-                    println!(
+                    eprintln!(
                         "[DEBUG] No AST blocks found for the range {start}-{end}, falling back to literal lines"
                     );
                 }
@@ -236,13 +236,13 @@ pub fn process_file_for_extraction(
     // Single line extraction
     else if let Some(line_num) = start_line {
         if debug_mode {
-            println!("[DEBUG] Single line extraction requested: line {line_num}");
+            eprintln!("[DEBUG] Single line extraction requested: line {line_num}");
         }
         // Clamp line number to valid range instead of failing
         let clamped_line_num = line_num.clamp(1, lines.len());
 
         if debug_mode && clamped_line_num != line_num {
-            println!(
+            eprintln!(
                 "[DEBUG] Requested line {line_num} out of bounds; clamping to {clamped_line_num}"
             );
         }
@@ -284,7 +284,7 @@ pub fn process_file_for_extraction(
                 let merged_end = max_end + 1;
 
                 if debug_mode {
-                    println!(
+                    eprintln!(
                         "[DEBUG] Found {} AST blocks for line {}, merging into lines {}-{}",
                         blocks.len(),
                         line_num,
@@ -331,7 +331,7 @@ pub fn process_file_for_extraction(
             _ => {
                 // If no AST block found, fallback to the line + context
                 if debug_mode {
-                    println!(
+                    eprintln!(
                         "[DEBUG] No AST blocks found for line {line_num}, using context-based fallback"
                     );
                 }
@@ -388,12 +388,12 @@ pub fn process_file_for_extraction(
     } else if let Some(lines_set) = specific_lines {
         // We have specific lines to extract
         if debug_mode {
-            println!("[DEBUG] Extracting specific lines: {lines_set:?}");
+            eprintln!("[DEBUG] Extracting specific lines: {lines_set:?}");
         }
 
         if lines_set.is_empty() {
             if debug_mode {
-                println!("[DEBUG] No specific lines provided, returning entire file content");
+                eprintln!("[DEBUG] No specific lines provided, returning entire file content");
             }
 
             // Tokenize the content
@@ -448,7 +448,7 @@ pub fn process_file_for_extraction(
         }
 
         if debug_mode && any_clamped {
-            println!(
+            eprintln!(
                 "[DEBUG] Some requested lines were out of bounds; clamping to valid range 1-{}",
                 lines.len()
             );
@@ -483,7 +483,7 @@ pub fn process_file_for_extraction(
                 let merged_end = max_end + 1;
 
                 if debug_mode {
-                    println!(
+                    eprintln!(
                         "[DEBUG] Found {} AST blocks for specific lines, merging into lines {}-{}",
                         blocks.len(),
                         merged_start,
@@ -530,7 +530,7 @@ pub fn process_file_for_extraction(
             _ => {
                 // Fallback to literal extraction of the specific lines
                 if debug_mode {
-                    println!(
+                    eprintln!(
                         "[DEBUG] No AST blocks found for specific lines, falling back to literal lines"
                     );
                 }
@@ -589,7 +589,7 @@ pub fn process_file_for_extraction(
     } else {
         // No line specified, return the entire file
         if debug_mode {
-            println!("[DEBUG] No line or range specified, returning entire file content");
+            eprintln!("[DEBUG] No line or range specified, returning entire file content");
         }
 
         // Tokenize the content

--- a/src/language/parser.rs
+++ b/src/language/parser.rs
@@ -1666,7 +1666,9 @@ fn process_cached_line_map(
                         // Keep both - don't remove, don't skip add
                     } else if !is_important && prev_is_important {
                         if debug_mode {
-                            eprintln!("DEBUG: Cache Dedupe: Skipping non-important contained block");
+                            eprintln!(
+                                "DEBUG: Cache Dedupe: Skipping non-important contained block"
+                            );
                         }
                         should_add = false;
                         break;

--- a/src/language/parser.rs
+++ b/src/language/parser.rs
@@ -330,7 +330,7 @@ fn find_immediate_next_node(node: Node<'_>) -> Option<Node<'_>> {
     // First try direct next sibling
     if let Some(next) = node.next_sibling() {
         if debug_mode {
-            println!(
+            eprintln!(
                 "DEBUG: Found immediate next sibling: type='{}', lines={}-{}",
                 next.kind(),
                 next.start_position().row + 1,
@@ -344,7 +344,7 @@ fn find_immediate_next_node(node: Node<'_>) -> Option<Node<'_>> {
     if let Some(parent) = node.parent() {
         if let Some(next_parent) = parent.next_sibling() {
             if debug_mode {
-                println!(
+                eprintln!(
                     "DEBUG: Found parent's next sibling: type='{}', lines={}-{}",
                     next_parent.kind(),
                     next_parent.start_position().row + 1,
@@ -356,7 +356,7 @@ fn find_immediate_next_node(node: Node<'_>) -> Option<Node<'_>> {
     }
 
     if debug_mode {
-        println!("DEBUG: No immediate next node found");
+        eprintln!("DEBUG: No immediate next node found");
     }
     None
 }
@@ -371,7 +371,7 @@ fn find_comment_context_node<'a>(
     let start_row = comment_node.start_position().row;
 
     if debug_mode {
-        println!(
+        eprintln!(
             "DEBUG: Finding context for comment at lines {}-{}: {}",
             comment_node.start_position().row + 1,
             comment_node.end_position().row + 1,
@@ -398,7 +398,7 @@ fn find_comment_context_node<'a>(
         // Found a non-comment sibling
         if language_impl.is_acceptable_parent(&sibling) {
             if debug_mode {
-                println!(
+                eprintln!(
                     "DEBUG: Found next non-comment sibling for comment at line {}: type='{}', lines={}-{}",
                     start_row + 1,
                     sibling.kind(),
@@ -411,7 +411,7 @@ fn find_comment_context_node<'a>(
             // If next sibling isn't acceptable, check its children
             if let Some(child) = find_acceptable_child(sibling, language_impl) {
                 if debug_mode {
-                    println!(
+                    eprintln!(
                         "DEBUG: Found acceptable child in next non-comment sibling for comment at line {}: type='{}', lines={}-{}",
                         start_row + 1,
                         child.kind(),
@@ -436,7 +436,7 @@ fn find_comment_context_node<'a>(
         if let Some(prev_sibling) = find_prev_sibling(comment_node) {
             if language_impl.is_acceptable_parent(&prev_sibling) {
                 if debug_mode {
-                    println!(
+                    eprintln!(
                         "DEBUG: Found previous sibling for comment at line {}: type='{}', lines={}-{}",
                         start_row + 1,
                         prev_sibling.kind(),
@@ -449,7 +449,7 @@ fn find_comment_context_node<'a>(
                 // If previous sibling isn't acceptable, check its children
                 if let Some(child) = find_acceptable_child(prev_sibling, language_impl) {
                     if debug_mode {
-                        println!(
+                        eprintln!(
                             "DEBUG: Found acceptable child in previous sibling for comment at line {}: type='{}', lines={}-{}",
                             start_row + 1,
                             child.kind(),
@@ -468,7 +468,7 @@ fn find_comment_context_node<'a>(
     while let Some(parent) = current.parent() {
         if language_impl.is_acceptable_parent(&parent) {
             if debug_mode {
-                println!(
+                eprintln!(
                     "DEBUG: Found parent for comment at line {}: type='{}', lines={}-{}",
                     start_row + 1,
                     parent.kind(),
@@ -485,7 +485,7 @@ fn find_comment_context_node<'a>(
     if let Some(next_node) = find_immediate_next_node(comment_node) {
         if language_impl.is_acceptable_parent(&next_node) {
             if debug_mode {
-                println!(
+                eprintln!(
                     "DEBUG: Using immediate next acceptable node: type='{}', lines={}-{}",
                     next_node.kind(),
                     next_node.start_position().row + 1,
@@ -498,7 +498,7 @@ fn find_comment_context_node<'a>(
         // Look for acceptable child in the next node
         if let Some(child) = find_acceptable_child(next_node, language_impl) {
             if debug_mode {
-                println!(
+                eprintln!(
                     "DEBUG: Found acceptable child in next node: type='{}', lines={}-{}",
                     child.kind(),
                     child.start_position().row + 1,
@@ -510,7 +510,7 @@ fn find_comment_context_node<'a>(
     }
 
     if debug_mode {
-        println!("DEBUG: No related node found for the comment");
+        eprintln!("DEBUG: No related node found for the comment");
     }
     None
 }
@@ -535,7 +535,7 @@ fn build_sparse_line_map<'a>(
     sorted_lines.sort();
 
     if debug_mode {
-        println!(
+        eprintln!(
             "DEBUG: SPARSE OPTIMIZATION - Building sparse line map for {} lines",
             sorted_lines.len()
         );
@@ -565,7 +565,7 @@ fn build_sparse_line_map<'a>(
     let mut sparse_map = SparseLineMap::new(base_offset);
 
     if debug_mode {
-        println!(
+        eprintln!(
             "DEBUG: SPARSE OPTIMIZATION - Target ranges: {target_ranges:?}, base_offset: {base_offset}"
         );
     }
@@ -588,7 +588,7 @@ fn build_sparse_line_map<'a>(
     }
 
     if debug_mode {
-        println!("DEBUG: SPARSE OPTIMIZATION - Built sparse line map with {} mappings (vs full file approach)", sparse_map.len());
+        eprintln!("DEBUG: SPARSE OPTIMIZATION - Built sparse line map with {} mappings (vs full file approach)", sparse_map.len());
     }
 
     sparse_map
@@ -620,7 +620,7 @@ fn process_node_sparse<'a>(
 
     if !intersects_target {
         if debug_mode {
-            println!(
+            eprintln!(
                 "DEBUG: SPARSE - Skipping node '{}' at lines {}-{} (no intersection)",
                 node.kind(),
                 start_row + 1,
@@ -700,7 +700,7 @@ fn process_node_sparse<'a>(
                 sparse_map.insert(line, cached_info);
 
                 if debug_mode {
-                    println!(
+                    eprintln!(
                         "DEBUG: SPARSE - Stored mapping for line {}: type='{}', is_comment={}, context={:?}",
                         line + 1,
                         node.kind(),
@@ -770,7 +770,7 @@ fn process_node<'a>(
 
     if !intersects_target {
         if debug_mode {
-            println!(
+            eprintln!(
                 "DEBUG: AST Node filtering - skipping node '{}' at lines {}-{} (no intersection with target ranges)",
                 node.kind(),
                 start_row + 1,
@@ -914,12 +914,12 @@ fn process_sparse_line_map(
         let line_idx = line.saturating_sub(1); // Adjust for 0-based indexing
 
         if debug_mode {
-            println!("DEBUG: Processing line {line} from sparse cache");
+            eprintln!("DEBUG: Processing line {line} from sparse cache");
         }
 
         if let Some(info) = sparse_line_map.get(line_idx) {
             if debug_mode {
-                println!(
+                eprintln!(
                     "DEBUG: Found sparse cached node info for line {}: original_type='{}', original_lines={}-{}, is_comment={}, is_test={}, context_kind={:?}, context_lines={:?}, context_is_test={:?}",
                     line,
                     info.node_kind,
@@ -943,7 +943,7 @@ fn process_sparse_line_map(
             // Handle Comments
             if info.is_comment {
                 if debug_mode {
-                    println!("DEBUG: Sparse Cache: Handling comment node at line {line}");
+                    eprintln!("DEBUG: Sparse Cache: Handling comment node at line {line}");
                 }
                 // Check for context node
                 if let (Some(ctx_rows), Some(ctx_bytes), Some(ctx_kind), Some(ctx_is_test)) = (
@@ -958,7 +958,7 @@ fn process_sparse_line_map(
 
                     if !should_use_context {
                         if debug_mode {
-                            println!(
+                            eprintln!(
                                 "DEBUG: Sparse Cache: Skipping test context node at lines {}-{}, type: {}",
                                 ctx_rows.0 + 1,
                                 ctx_rows.1 + 1,
@@ -985,7 +985,7 @@ fn process_sparse_line_map(
                                 parent_end_row: None,
                             });
                             if debug_mode {
-                                println!(
+                                eprintln!(
                                     "DEBUG: Sparse Cache: Potential merged block (comment + context) at lines {}-{}, type: {}",
                                     merged_start_row + 1, merged_end_row + 1, ctx_kind
                                 );
@@ -1009,7 +1009,7 @@ fn process_sparse_line_map(
 
                                 if should_filter {
                                     if debug_mode {
-                                        println!(
+                                        eprintln!(
                                             "DEBUG: Sparse Cache: Filtering out complete test function block at lines {}-{}, type: {}",
                                             block.start_row + 1, block.end_row + 1, block.node_type
                                         );
@@ -1039,7 +1039,7 @@ fn process_sparse_line_map(
                             parent_end_row: None,
                         });
                         if debug_mode {
-                            println!(
+                            eprintln!(
                                 "DEBUG: Sparse Cache: Potential individual comment block at lines {}-{}",
                                 info.start_row + 1,
                                 info.end_row + 1
@@ -1053,7 +1053,7 @@ fn process_sparse_line_map(
                 // Skip original test nodes if not allowed
                 if !allow_tests && info.is_test {
                     if debug_mode {
-                        println!(
+                        eprintln!(
                             "DEBUG: Sparse Cache: Skipping original test node at lines {}-{}",
                             info.start_row + 1,
                             info.end_row + 1
@@ -1071,7 +1071,7 @@ fn process_sparse_line_map(
                 ) {
                     if !allow_tests && ctx_is_test {
                         if debug_mode {
-                            println!(
+                            eprintln!(
                                 "DEBUG: Sparse Cache: Skipping test context node (ancestor) at lines {}-{}",
                                 ctx_rows.0 + 1, ctx_rows.1 + 1
                             );
@@ -1091,7 +1091,7 @@ fn process_sparse_line_map(
                                 parent_end_row: info.parent_end_row,
                             });
                             if debug_mode {
-                                println!(
+                                eprintln!(
                                     "DEBUG: Sparse Cache: Potential context node (ancestor) block at lines {}-{}",
                                     ctx_rows.0 + 1, ctx_rows.1 + 1
                                 );
@@ -1124,7 +1124,7 @@ fn process_sparse_line_map(
                             parent_end_row: info.parent_end_row,
                         });
                         if debug_mode {
-                            println!(
+                            eprintln!(
                                 "DEBUG: Sparse Cache: Potential acceptable original node block at lines {}-{}",
                                 info.start_row + 1, info.end_row + 1
                             );
@@ -1138,7 +1138,7 @@ fn process_sparse_line_map(
                 if !seen_block_spans.contains(&key) {
                     seen_block_spans.insert(key);
                     if debug_mode {
-                        println!(
+                        eprintln!(
                             "DEBUG: Sparse Cache: Added new block at lines {}-{}, type: {}",
                             key.0 + 1,
                             key.1 + 1,
@@ -1149,7 +1149,7 @@ fn process_sparse_line_map(
                 }
             }
         } else if debug_mode {
-            println!("DEBUG: Sparse Cache: No cached node info found for line {line}");
+            eprintln!("DEBUG: Sparse Cache: No cached node info found for line {line}");
         }
     }
 
@@ -1303,19 +1303,19 @@ fn process_cached_line_map(
         let line_idx = line.saturating_sub(1); // Adjust for 0-based indexing
 
         if debug_mode {
-            println!("DEBUG: Processing line {line} from cache");
+            eprintln!("DEBUG: Processing line {line} from cache");
         }
 
         if line_idx >= cached_line_map.len() {
             if debug_mode {
-                println!("DEBUG: Line {line} is out of bounds (Cache)");
+                eprintln!("DEBUG: Line {line} is out of bounds (Cache)");
             }
             continue;
         }
 
         if let Some(info) = &cached_line_map[line_idx] {
             if debug_mode {
-                println!(
+                eprintln!(
                     "DEBUG: Found cached node info for line {}: original_type='{}', original_lines={}-{}, is_comment={}, is_test={}, context_kind={:?}, context_lines={:?}",
                     line,
                     info.node_kind,
@@ -1337,7 +1337,7 @@ fn process_cached_line_map(
             // 1. Handle Comments
             if info.is_comment {
                 if debug_mode {
-                    println!("DEBUG: Cache: Handling comment node at line {line}");
+                    eprintln!("DEBUG: Cache: Handling comment node at line {line}");
                 }
                 // Check for context node
                 if let (Some(ctx_rows), Some(ctx_bytes), Some(ctx_kind), Some(ctx_is_test)) = (
@@ -1349,7 +1349,7 @@ fn process_cached_line_map(
                     // Check test status of the context node
                     if !allow_tests && ctx_is_test {
                         if debug_mode {
-                            println!(
+                            eprintln!(
                                 "DEBUG: Cache: Skipping test context node at lines {}-{}, type: {}",
                                 ctx_rows.0 + 1,
                                 ctx_rows.1 + 1,
@@ -1377,7 +1377,7 @@ fn process_cached_line_map(
                                 parent_end_row: None,
                             });
                             if debug_mode {
-                                println!(
+                                eprintln!(
                                     "DEBUG: Cache: Potential merged block (comment + context) at lines {}-{}, type: {}",
                                     merged_start_row + 1, merged_end_row + 1, ctx_kind
                                 );
@@ -1389,7 +1389,7 @@ fn process_cached_line_map(
                             || potential_block.is_some()
                         {
                             if seen_block_spans.contains(&block_key.unwrap()) && debug_mode {
-                                println!(
+                                eprintln!(
                                     "DEBUG: Cache: Merged block span {}-{} already seen",
                                     block_key.unwrap().0 + 1,
                                     block_key.unwrap().1 + 1
@@ -1422,14 +1422,14 @@ fn process_cached_line_map(
                             parent_end_row: None,
                         });
                         if debug_mode {
-                            println!(
+                            eprintln!(
                                 "DEBUG: Cache: Potential individual comment block at lines {}-{}",
                                 info.start_row + 1,
                                 info.end_row + 1
                             );
                         }
                     } else if debug_mode {
-                        println!(
+                        eprintln!(
                             "DEBUG: Cache: Individual comment span {}-{} already seen",
                             block_key.unwrap().0 + 1,
                             block_key.unwrap().1 + 1
@@ -1442,7 +1442,7 @@ fn process_cached_line_map(
                 // Skip original test nodes if not allowed
                 if !allow_tests && info.is_test {
                     if debug_mode {
-                        println!(
+                        eprintln!(
                             "DEBUG: Cache: Skipping original test node at lines {}-{}",
                             info.start_row + 1,
                             info.end_row + 1
@@ -1461,7 +1461,7 @@ fn process_cached_line_map(
                     // Check test status of the context node
                     if !allow_tests && ctx_is_test {
                         if debug_mode {
-                            println!(
+                            eprintln!(
                                 "DEBUG: Cache: Skipping test context node (ancestor) at lines {}-{}",
                                 ctx_rows.0 + 1, ctx_rows.1 + 1
                             );
@@ -1483,13 +1483,13 @@ fn process_cached_line_map(
                                 parent_end_row: info.parent_end_row,
                             });
                             if debug_mode {
-                                println!(
+                                eprintln!(
                                     "DEBUG: Cache: Potential context node (ancestor) block at lines {}-{}",
                                     ctx_rows.0 + 1, ctx_rows.1 + 1
                                 );
                             }
                         } else if debug_mode {
-                            println!(
+                            eprintln!(
                                 "DEBUG: Cache: Context node span {}-{} already seen",
                                 block_key.unwrap().0 + 1,
                                 block_key.unwrap().1 + 1
@@ -1525,13 +1525,13 @@ fn process_cached_line_map(
                             parent_end_row: info.parent_end_row,
                         });
                         if debug_mode {
-                            println!(
+                            eprintln!(
                                 "DEBUG: Cache: Potential acceptable original node block at lines {}-{}",
                                 info.start_row + 1, info.end_row + 1
                             );
                         }
                     } else if debug_mode {
-                        println!(
+                        eprintln!(
                             "DEBUG: Cache: Original acceptable node span {}-{} already seen",
                             block_key.unwrap().0 + 1,
                             block_key.unwrap().1 + 1
@@ -1561,7 +1561,7 @@ fn process_cached_line_map(
                             (Some(cur_pri), Some(exist_pri)) if cur_pri > exist_pri => {
                                 // Replace with higher priority node
                                 if debug_mode {
-                                    println!(
+                                    eprintln!(
                                         "DEBUG: Cache: Replaced block at lines {}-{} with higher priority type: {} > {}",
                                         key.0 + 1, key.1 + 1, block.node_type, existing_node_type
                                     );
@@ -1571,7 +1571,7 @@ fn process_cached_line_map(
                             _ => {
                                 // Keep existing (higher or equal priority)
                                 if debug_mode {
-                                    println!(
+                                    eprintln!(
                                         "DEBUG: Cache: Keeping existing block at lines {}-{} with priority: {} >= {}",
                                         key.0 + 1, key.1 + 1,
                                         existing_node_type, block.node_type
@@ -1584,7 +1584,7 @@ fn process_cached_line_map(
                     // New span - add it
                     seen_block_spans.insert(key);
                     if debug_mode {
-                        println!(
+                        eprintln!(
                             "DEBUG: Cache: Added new block at lines {}-{}, type: {}",
                             key.0 + 1,
                             key.1 + 1,
@@ -1595,7 +1595,7 @@ fn process_cached_line_map(
                 }
             }
         } else if debug_mode {
-            println!("DEBUG: Cache: No cached node info found for line {line}");
+            eprintln!("DEBUG: Cache: No cached node info found for line {line}");
         }
     }
 
@@ -1653,7 +1653,7 @@ fn process_cached_line_map(
                 // Case 1: Current block is contained within previous block
                 if block.start_row >= prev_block.start_row && block.end_row <= prev_block.end_row {
                     if debug_mode {
-                        println!(
+                        eprintln!(
                             "DEBUG: Cache Dedupe: Current block contained: type='{}', lines={}-{} (in type='{}', lines={}-{})",
                             block.node_type, block.start_row + 1, block.end_row + 1,
                             prev_block.node_type, prev_block.start_row + 1, prev_block.end_row + 1
@@ -1661,12 +1661,12 @@ fn process_cached_line_map(
                     }
                     if is_important && !prev_is_important {
                         if debug_mode {
-                            println!("DEBUG: Cache Dedupe: Keeping important contained block");
+                            eprintln!("DEBUG: Cache Dedupe: Keeping important contained block");
                         }
                         // Keep both - don't remove, don't skip add
                     } else if !is_important && prev_is_important {
                         if debug_mode {
-                            println!("DEBUG: Cache Dedupe: Skipping non-important contained block");
+                            eprintln!("DEBUG: Cache Dedupe: Skipping non-important contained block");
                         }
                         should_add = false;
                         break;
@@ -1684,14 +1684,14 @@ fn process_cached_line_map(
                                 if cur_pri > prev_pri {
                                     // Current block has higher priority - keep it, remove previous
                                     if debug_mode {
-                                        println!("DEBUG: Cache Dedupe: Replacing block with higher priority type: {} > {}", 
+                                        eprintln!("DEBUG: Cache Dedupe: Replacing block with higher priority type: {} > {}", 
                                                 block.node_type, prev_block.node_type);
                                     }
                                     blocks_to_remove.push(idx);
                                 } else {
                                     // Previous block has higher or equal priority - keep previous, skip current
                                     if debug_mode {
-                                        println!("DEBUG: Cache Dedupe: Skipping block in favor of higher priority type: {} >= {}", 
+                                        eprintln!("DEBUG: Cache Dedupe: Skipping block in favor of higher priority type: {} >= {}", 
                                                 prev_block.node_type, block.node_type);
                                     }
                                     should_add = false;
@@ -1701,7 +1701,7 @@ fn process_cached_line_map(
                             _ => {
                                 // Fallback: prefer contained (current) block for consistency
                                 if debug_mode {
-                                    println!("DEBUG: Cache Dedupe: Replacing outer block with contained block (no priority)");
+                                    eprintln!("DEBUG: Cache Dedupe: Replacing outer block with contained block (no priority)");
                                 }
                                 blocks_to_remove.push(idx);
                             }
@@ -1713,7 +1713,7 @@ fn process_cached_line_map(
                     && prev_block.end_row <= block.end_row
                 {
                     if debug_mode {
-                        println!(
+                        eprintln!(
                             "DEBUG: Cache Dedupe: Previous block contained: type='{}', lines={}-{} (contains type='{}', lines={}-{})",
                             block.node_type, block.start_row + 1, block.end_row + 1,
                             prev_block.node_type, prev_block.start_row + 1, prev_block.end_row + 1
@@ -1721,12 +1721,12 @@ fn process_cached_line_map(
                     }
                     if is_important && !prev_is_important {
                         if debug_mode {
-                            println!("DEBUG: Cache Dedupe: Keeping important outer block");
+                            eprintln!("DEBUG: Cache Dedupe: Keeping important outer block");
                         }
                         // Keep both - don't skip add, continue checking
                     } else if !is_important && prev_is_important {
                         if debug_mode {
-                            println!("DEBUG: Cache Dedupe: Skipping non-important outer block");
+                            eprintln!("DEBUG: Cache Dedupe: Skipping non-important outer block");
                         }
                         should_add = false;
                         break;
@@ -1744,14 +1744,14 @@ fn process_cached_line_map(
                                 if cur_pri > prev_pri {
                                     // Current block has higher priority - keep it, remove previous
                                     if debug_mode {
-                                        println!("DEBUG: Cache Dedupe: Replacing contained block with higher priority type: {} > {}", 
+                                        eprintln!("DEBUG: Cache Dedupe: Replacing contained block with higher priority type: {} > {}", 
                                                 block.node_type, prev_block.node_type);
                                     }
                                     blocks_to_remove.push(idx);
                                 } else {
                                     // Previous block has higher or equal priority - keep previous, skip current
                                     if debug_mode {
-                                        println!("DEBUG: Cache Dedupe: Skipping outer block in favor of higher priority contained type: {} >= {}", 
+                                        eprintln!("DEBUG: Cache Dedupe: Skipping outer block in favor of higher priority contained type: {} >= {}", 
                                                 prev_block.node_type, block.node_type);
                                     }
                                     should_add = false;
@@ -1761,7 +1761,7 @@ fn process_cached_line_map(
                             _ => {
                                 // Fallback: prefer contained (previous) block for consistency
                                 if debug_mode {
-                                    println!("DEBUG: Cache Dedupe: Skipping outer block (already have contained, no priority)");
+                                    eprintln!("DEBUG: Cache Dedupe: Skipping outer block (already have contained, no priority)");
                                 }
                                 should_add = false;
                                 break;
@@ -1772,7 +1772,7 @@ fn process_cached_line_map(
                 // Case 3: Blocks partially overlap
                 else {
                     if debug_mode {
-                        println!(
+                        eprintln!(
                             "DEBUG: Cache Dedupe: Partial overlap: type='{}', lines={}-{} (overlaps type='{}', lines={}-{})",
                             block.node_type, block.start_row + 1, block.end_row + 1,
                             prev_block.node_type, prev_block.start_row + 1, prev_block.end_row + 1
@@ -1850,7 +1850,7 @@ pub fn parse_file_for_code_blocks_with_tree(
     // Check if we have a cached sparse line map
     if let Some(cached_entry) = LINE_MAP_CACHE.get(&cache_key) {
         if debug_mode {
-            println!("DEBUG: Sparse cache hit for line_map key: {cache_key}");
+            eprintln!("DEBUG: Sparse cache hit for line_map key: {cache_key}");
         }
 
         // Process the sparse cached line map
@@ -1865,7 +1865,7 @@ pub fn parse_file_for_code_blocks_with_tree(
     }
 
     if debug_mode {
-        println!(
+        eprintln!(
             "DEBUG: Sparse cache miss for line_map key: {cache_key}. Building sparse line map..."
         );
     }
@@ -1873,7 +1873,7 @@ pub fn parse_file_for_code_blocks_with_tree(
     // Get the tree - either use pre-parsed or parse it
     let tree = if let Some(pre_parsed) = pre_parsed_tree {
         if debug_mode {
-            println!("DEBUG: Using pre-parsed tree, skipping redundant parsing");
+            eprintln!("DEBUG: Using pre-parsed tree, skipping redundant parsing");
         }
         pre_parsed
     } else {
@@ -1893,8 +1893,8 @@ pub fn parse_file_for_code_blocks_with_tree(
     let root_node = tree.root_node();
 
     if debug_mode {
-        println!("DEBUG: SPARSE OPTIMIZATION - Parsing file with extension: {extension}");
-        println!(
+        eprintln!("DEBUG: SPARSE OPTIMIZATION - Parsing file with extension: {extension}");
+        eprintln!(
             "DEBUG: SPARSE OPTIMIZATION - Root node type: {}",
             root_node.kind()
         );
@@ -1911,7 +1911,7 @@ pub fn parse_file_for_code_blocks_with_tree(
     );
 
     if debug_mode {
-        println!(
+        eprintln!(
             "DEBUG: SPARSE OPTIMIZATION - Sparse line map built with {} entries",
             sparse_line_map.len()
         );
@@ -1929,7 +1929,7 @@ pub fn parse_file_for_code_blocks_with_tree(
     // Store the sparse line map in cache for future requests
     LINE_MAP_CACHE.insert(cache_key.clone(), sparse_line_map);
     if debug_mode {
-        println!("DEBUG: SPARSE OPTIMIZATION - Stored sparse line map in cache key: {cache_key}");
+        eprintln!("DEBUG: SPARSE OPTIMIZATION - Stored sparse line map in cache key: {cache_key}");
     }
 
     Ok(code_blocks)

--- a/src/language/tree_cache.rs
+++ b/src/language/tree_cache.rs
@@ -89,7 +89,7 @@ pub fn get_or_parse_tree(
                 }
 
                 if debug_mode {
-                    println!("[DEBUG] Cache hit for file: {file_path}");
+                    eprintln!("[DEBUG] Cache hit for file: {file_path}");
                 }
                 // PHASE 4 OPTIMIZATION: Now update LRU order with get
                 let (cached_tree, _) = cache.get(file_path).unwrap();
@@ -99,11 +99,11 @@ pub fn get_or_parse_tree(
                 // PHASE 4 OPTIMIZATION: LRU cache uses pop instead of remove
                 cache.pop(file_path);
                 if debug_mode {
-                    println!("[DEBUG] Cache invalidated for file: {file_path} (content changed)");
+                    eprintln!("[DEBUG] Cache invalidated for file: {file_path} (content changed)");
                 }
             }
         } else if debug_mode {
-            println!("[DEBUG] Cache miss for file: {file_path}");
+            eprintln!("[DEBUG] Cache miss for file: {file_path}");
         }
     }
 
@@ -121,8 +121,8 @@ pub fn get_or_parse_tree(
         cache.put(file_path.to_string(), (tree.clone(), content_hash));
 
         if debug_mode {
-            println!("[DEBUG] Cached parsed tree for file: {file_path}");
-            println!("[DEBUG] Current cache size: {} entries", cache.len());
+            eprintln!("[DEBUG] Cached parsed tree for file: {file_path}");
+            eprintln!("[DEBUG] Current cache size: {} entries", cache.len());
         }
     }
 
@@ -170,7 +170,7 @@ pub fn get_or_parse_tree_pooled(file_path: &str, content: &str, extension: &str)
                 }
 
                 if debug_mode {
-                    println!("[DEBUG] Tree cache hit for file: {file_path}");
+                    eprintln!("[DEBUG] Tree cache hit for file: {file_path}");
                 }
                 // PHASE 4 OPTIMIZATION: Now update LRU order with get
                 let (cached_tree, _) = cache.get(file_path).unwrap();
@@ -186,7 +186,7 @@ pub fn get_or_parse_tree_pooled(file_path: &str, content: &str, extension: &str)
                 }
             }
         } else if debug_mode {
-            println!("[DEBUG] Tree cache miss for file: {file_path}");
+            eprintln!("[DEBUG] Tree cache miss for file: {file_path}");
         }
     }
 
@@ -211,8 +211,8 @@ pub fn get_or_parse_tree_pooled(file_path: &str, content: &str, extension: &str)
         cache.put(file_path.to_string(), (tree.clone(), content_hash));
 
         if debug_mode {
-            println!("[DEBUG] Cached parsed tree for file: {file_path}");
-            println!("[DEBUG] Current tree cache size: {} entries", cache.len());
+            eprintln!("[DEBUG] Cached parsed tree for file: {file_path}");
+            eprintln!("[DEBUG] Current tree cache size: {} entries", cache.len());
         }
     }
 
@@ -230,7 +230,7 @@ pub fn clear_tree_cache() {
     let debug_mode = std::env::var("DEBUG").unwrap_or_default() == "1";
 
     if debug_mode {
-        println!("[DEBUG] Clearing tree cache ({} entries)", cache.len());
+        eprintln!("[DEBUG] Clearing tree cache ({} entries)", cache.len());
     }
 
     cache.clear();
@@ -255,7 +255,7 @@ pub fn invalidate_cache_entry(file_path: &str) {
     let debug_mode = std::env::var("DEBUG").unwrap_or_default() == "1";
 
     if cache.pop(file_path).is_some() && debug_mode {
-        println!("[DEBUG] Removed file from cache: {file_path}");
+        eprintln!("[DEBUG] Removed file from cache: {file_path}");
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes stdout pollution issues in extract command when using JSON or XML output formats. Previously, status messages, debug output, and other text were being sent to stdout, making the structured output unparseable and unusable for programmatic consumption.

## Problem
The extract command was polluting stdout with:
- Status messages ("Reading from clipboard...", "Reading from stdin...")  
- File information blocks ("Files to extract:", "Format: json")
- Success messages ("Results copied to clipboard.")
- Debug output (when DEBUG=1 was set)
- Error messages in some cases

This made JSON/XML output unusable with tools like `jq`, XML parsers, or any programmatic consumption.

## Solution
- **Guard status messages**: Only display when `format \!= "json" && format \!= "xml"`
- **Fix debug output**: Convert all `println\!` debug statements to `eprintln\!` (stderr)
- **Preserve UX**: Non-structured formats still show user-friendly messages
- **Clean separation**: stdout = structured data, stderr = human-readable messages

## Changes
- `src/extract/mod.rs`: Guard status messages, fix debug output routing
- `src/extract/processor.rs`: Convert all debug println\! to eprintln\! 
- `src/language/parser.rs`: Fix 46+ debug statements going to stdout
- `src/language/tree_cache.rs`: Fix cache debug statements

## Testing
✅ **JSON output is clean**: `./probe extract file.rs --format json | jq`  
✅ **XML output is clean**: `./probe extract file.rs --format xml`  
✅ **Debug mode works**: `DEBUG=1 ./probe extract file.rs --format json 2>/dev/null`  
✅ **All input methods**: stdin, clipboard, file args all produce clean output  
✅ **All 155 tests pass**: No functionality broken  

## Before/After

**Before (JSON mode):**
```
Reading from stdin...
Files to extract:
  src/main.rs (lines 1-5)
Format: json

[DEBUG] Processing file...
{ "results": [...] }
```

**After (JSON mode):**
```
{ "results": [...] }
```
(Debug info goes to stderr when DEBUG=1 is set)

🤖 Generated with [Claude Code](https://claude.ai/code)